### PR TITLE
Added option to reboot to payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 su
 .vscode
+libs/borealis/library/

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ DATA		:=	data
 INCLUDES	:=	include libs/zipper/include
 APP_TITLE   :=  Linkalho
 APP_AUTHOR  :=  rrocha
-APP_VERSION :=  1.0.1
+APP_VERSION :=  1.0.2
 # ROMFS		:=	romfs
 
 # ROMFS				:=	libs/borealis/resources

--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ This operation creates a backup in `/switch/linkalho/backups`
   - [natinusala (lib borealis)](https://github.com/natinusala/borealis) for the amazing library that mimicks the Switch's original UI and UX
   - [sebastiandev (zipper wrapper for minizip)](https://github.com/sebastiandev/zipper/) for their nice wrapper to the minizip
   - [Kronos2308](https://github.com/Kronos2308) for the help in the initial phases of research.
+  - [SciresM](https://github.com/SciresM) for his "reboot to payload" code and [HamletDuFromage](https://github.com/HamletDuFromage) for its implementation in Linkalho
   - **stick2target** for the beta testing and for supplying crucial files that helped in the creation of the generators.
   - **boredomisacrime** for the beta testing.

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -15,5 +15,8 @@
 #endif
 # define RESTORE_PATH ACCOUNT_PATH
 
+#define AMS_PAYLOAD "sdmc:/atmosphere/reboot_payload.bin"
+#define SXOS_PAYLOAD "sdmc:/boot.dat"
+#define REINX_PAYLOAD "sdmc:/ReiNX.bin"
 
 #endif // __LINKUSER_CONSTANTS_HPP__

--- a/include/reboot_payload.h
+++ b/include/reboot_payload.h
@@ -1,0 +1,29 @@
+#ifndef __REBBOT_PAYLOAD_H__
+#define __REBBOT_PAYLOAD_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <switch.h>
+
+enum CFW{
+    ams,
+    rnx,
+    sxos,
+};
+
+bool is_service_sunning(const char *serviceName);
+
+enum CFW get_CFW();
+
+int reboot_to_payload();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/reboot_payload.h
+++ b/include/reboot_payload.h
@@ -1,5 +1,5 @@
-#ifndef __REBBOT_PAYLOAD_H__
-#define __REBBOT_PAYLOAD_H__
+#ifndef __REBOOT_PAYLOAD_H__
+#define __REBOOT_PAYLOAD_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,7 +16,7 @@ enum CFW{
     sxos,
 };
 
-bool is_service_sunning(const char *serviceName);
+bool is_service_running(const char *serviceName);
 
 enum CFW get_CFW();
 

--- a/include/reboot_payload.h
+++ b/include/reboot_payload.h
@@ -10,16 +10,6 @@ extern "C" {
 #include <stdbool.h>
 #include <switch.h>
 
-enum CFW{
-    ams,
-    rnx,
-    sxos,
-};
-
-bool is_service_running(const char *serviceName);
-
-enum CFW get_CFW();
-
 int reboot_to_payload();
 
 #ifdef __cplusplus

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,23 +1,6 @@
-#ifndef __LINKUSER_UTILS_HPP__
-#define __LINKUSER_UTILS_HPP__
-
 #include <switch.h>
 #include <iostream>
 #include "constants.hpp"
 
-void attempt_reboot(){
-#ifndef DEBUG
-    Result rc = bpcInitialize();
-    if (R_FAILED(rc))
-        printf("bpcInit: %08X\n", rc);
-    else
-    {
-        bpcRebootSystem();
-        bpcExit();
-    }
-#else
-    std::cout << "Reboot would happen here" << std::endl;
-#endif
-}
 
-#endif // __LINKUSER_UTILS_HPP__
+void attempt_reboot();

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,9 +2,8 @@
 #define __LINKUSER_UTILS_HPP__
 
 #include <switch.h>
-#include <iostream>
 #include "constants.hpp"
-
+#include <iostream>
 
 void attempt_reboot();
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -7,4 +7,8 @@
 
 void attempt_reboot();
 
+extern "C" bool is_service_running(const char *serviceName);
+
+extern "C" int get_CFW();
+
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,11 @@
+#ifndef __LINKUSER_UTILS_HPP__
+#define __LINKUSER_UTILS_HPP__
+
 #include <switch.h>
 #include <iostream>
 #include "constants.hpp"
 
 
 void attempt_reboot();
+
+#endif

--- a/src/confirm_page.cpp
+++ b/src/confirm_page.cpp
@@ -1,17 +1,19 @@
 #include "confirm_page.hpp"
 #include <borealis.hpp>
 #include "utils.hpp"
+#include "reboot_payload.h"
 #include <algorithm>
 
 ConfirmPage::ConfirmPage(brls::StagedAppletFrame* frame, const std::string& text, bool reboot): reboot(reboot)
 {
-    this->button = (new brls::Button(reboot ? brls::ButtonStyle::BORDERLESS: brls::ButtonStyle::PLAIN))->setLabel(reboot ? "Reboot": "Continue");
+    this->button = (new brls::Button(reboot ? brls::ButtonStyle::BORDERLESS: brls::ButtonStyle::PLAIN))->setLabel(reboot ? "Reboot to payload": "Continue");
 
     this->button->setParent(this);
     this->button->getClickEvent()->subscribe([frame, this](View* view) {
         if (!frame->isLastStage())
             frame->nextStage();
         else if (this->reboot) {
+            reboot_to_payload();
             attempt_reboot();
             brls::Application::popView();
         }
@@ -34,7 +36,7 @@ void ConfirmPage::draw(NVGcontext* vg, int x, int y, unsigned width, unsigned he
     if (!this->reboot) {
         auto end = std::chrono::high_resolution_clock::now();
         auto missing = std::max(3l - std::chrono::duration_cast<std::chrono::seconds>(end - start).count(), 0l);
-        auto text =  std::string(this->reboot ? "Reboot": "Continue");
+        auto text =  std::string(this->reboot ? "Reboot to payload": "Continue");
         if (missing > 0) {
             this->button->setLabel(text + " (" + std::to_string(missing) + ")");
             this->button->setState(brls::ButtonState::DISABLED);

--- a/src/reboot_payload.c
+++ b/src/reboot_payload.c
@@ -1,0 +1,108 @@
+#include "reboot_payload.h"
+
+#define IRAM_PAYLOAD_MAX_SIZE 0x2F000
+#define IRAM_PAYLOAD_BASE 0x40010000
+
+static alignas(0x1000) u8 g_reboot_payload[IRAM_PAYLOAD_MAX_SIZE];
+static alignas(0x1000) u8 g_ff_page[0x1000];
+static alignas(0x1000) u8 g_work_page[0x1000];
+
+bool is_service_running(const char *serviceName) {
+  Handle handle;
+  SmServiceName service_name = smEncodeName(serviceName);
+  bool running = R_FAILED(smRegisterService(&handle, service_name, false, 1));
+
+  svcCloseHandle(handle);
+
+  if (!running)
+    smUnregisterService(service_name);
+
+  return running;
+}
+
+enum CFW get_CFW(){
+    if(is_service_running("rnx"))         return rnx;
+    else if(is_service_running("tx"))     return sxos;
+    else                                return ams;
+}
+
+
+void do_iram_dram_copy(void *buf, uintptr_t iram_addr, size_t size, int option) {
+    memcpy(g_work_page, buf, size);
+    
+    SecmonArgs args = {0};
+    args.X[0] = 0xF0000201;             /* smcAmsIramCopy */
+    args.X[1] = (uintptr_t)g_work_page;  /* DRAM Address */
+    args.X[2] = iram_addr;              /* IRAM Address */
+    args.X[3] = size;                   /* Copy size */
+    args.X[4] = option;                 /* 0 = Read, 1 = Write */
+    svcCallSecureMonitor(&args);
+    
+    memcpy(buf, g_work_page, size);
+}
+
+void copy_to_iram(uintptr_t iram_addr, void *buf, size_t size) {
+    do_iram_dram_copy(buf, iram_addr, size, 1);
+}
+
+void copy_from_iram(void *buf, uintptr_t iram_addr, size_t size) {
+    do_iram_dram_copy(buf, iram_addr, size, 0);
+}
+
+static void clear_iram(void) {
+    memset(g_ff_page, 0xFF, sizeof(g_ff_page));
+    for (size_t i = 0; i < IRAM_PAYLOAD_MAX_SIZE; i += sizeof(g_ff_page)) {
+        copy_to_iram(IRAM_PAYLOAD_BASE + i, g_ff_page, sizeof(g_ff_page));
+    }
+}
+
+static void inject_payload(void) {
+    clear_iram();
+    
+    for (size_t i = 0; i < IRAM_PAYLOAD_MAX_SIZE; i += 0x1000) {
+        copy_to_iram(IRAM_PAYLOAD_BASE + i, &g_reboot_payload[i], 0x1000);
+    }
+    
+    splSetConfig((SplConfigItem)65001, 2);
+}
+
+int reboot_to_payload(){
+    bool can_reboot = true;
+    int cfw = get_CFW();
+    Result rc = splInitialize();
+    if (R_FAILED(rc)) {
+        printf("Failed to initialize spl: 0x%x\n", rc);
+        can_reboot = false;
+    } else {
+        FILE *f;
+        switch(cfw){
+            case ams:
+                f = fopen("sdmc:/atmosphere/reboot_payload.bin", "rb");
+                break;
+            case rnx:
+                f = fopen("sdmc:/ReiNX.bin", "rb");
+                break;
+            case sxos:
+                f = fopen("sdmc:/boot.dat", "rb");
+                break;
+        }
+        
+        if (f == NULL) {
+            //printf("Failed to open reboot_payload.bin!\n");
+            can_reboot = false;
+        } else {
+            fread(g_reboot_payload, 1, sizeof(g_reboot_payload), f);
+            fclose(f);
+            //printf("Press [-] to reboot to payload\n");
+        }
+    }
+    if (can_reboot) {
+        inject_payload();
+    }
+    if (can_reboot) {
+        splExit();
+    }
+    //attempt_reboot(); //if payload failed
+    return 0;
+
+}

--- a/src/reboot_payload.c
+++ b/src/reboot_payload.c
@@ -1,31 +1,14 @@
 #include "reboot_payload.h"
 #include "constants.hpp"
 
-#define IRAM_PAYLOAD_MAX_SIZE 0x2F000
-#define IRAM_PAYLOAD_BASE 0x40010000
+#define IRAM_PAYLOAD_MAX_SIZE   0x2F000
+#define IRAM_PAYLOAD_BASE       0x40010000
 
 static alignas(0x1000) u8 g_reboot_payload[IRAM_PAYLOAD_MAX_SIZE];
 static alignas(0x1000) u8 g_ff_page[0x1000];
 static alignas(0x1000) u8 g_work_page[0x1000];
 
-bool is_service_running(const char *serviceName) {
-  Handle handle;
-  SmServiceName service_name = smEncodeName(serviceName);
-  bool running = R_FAILED(smRegisterService(&handle, service_name, false, 1));
 
-  svcCloseHandle(handle);
-
-  if (!running)
-    smUnregisterService(service_name);
-
-  return running;
-}
-
-enum CFW get_CFW(){
-    if(is_service_running("rnx"))         return rnx;
-    else if(is_service_running("tx"))     return sxos;
-    else                                return ams;
-}
 void do_iram_dram_copy(void *buf, uintptr_t iram_addr, size_t size, int option) {
     memcpy(g_work_page, buf, size);
     
@@ -73,14 +56,14 @@ int reboot_to_payload(){
     else {
         FILE *f;
         switch(cfw){
-            case ams:
-                f = fopen(AMS_PAYLOAD, "rb");
-                break;
-            case rnx:
+            case 0:
                 f = fopen(REINX_PAYLOAD, "rb");
                 break;
-            case sxos:
+            case 1:
                 f = fopen(SXOS_PAYLOAD, "rb");
+                break;
+            case 2:
+                f = fopen(AMS_PAYLOAD, "rb");
                 break;
         }
         if (f == NULL) can_reboot = false;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-
 void attempt_reboot(){
 #ifndef DEBUG
     Result rc = bpcInitialize();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,3 +14,23 @@ void attempt_reboot(){
     std::cout << "Reboot would happen here" << std::endl;
 #endif
 }
+
+bool is_service_running(const char *serviceName) {
+    Handle handle;
+    SmServiceName service_name = smEncodeName(serviceName);
+    bool running = R_FAILED(smRegisterService(&handle, service_name, false, 1));
+
+    svcCloseHandle(handle);
+
+    if (!running)
+        smUnregisterService(service_name);
+
+    return running;
+}
+
+int get_CFW() {
+    if(is_service_running("rnx"))       return 0; //ReiNX
+    else if(is_service_running("tx"))   return 1; //SXOS
+    else                                return 2; // Atmosphere
+}
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,17 @@
+#include "utils.hpp"
+
+
+void attempt_reboot(){
+#ifndef DEBUG
+    Result rc = bpcInitialize();
+    if (R_FAILED(rc))
+        printf("bpcInit: %08X\n", rc);
+    else
+    {
+        bpcRebootSystem();
+        bpcExit();
+    }
+#else
+    std::cout << "Reboot would happen here" << std::endl;
+#endif
+}


### PR DESCRIPTION
Absolutely love this homebrew. I tried writing it a few months ago but was too dumb to succeed.

I added an automatic reboot to payload (which turns off the console like previously if it fails) to not have to go look for a jig and/or a cable.

I tested it with Atmosphere, it should also work fine with ReiNX and probably with SXOS too but I haven't tested those two. The code mostly comes from Atmosphere, and I took the vain liberty to credit myself in the README, but you're free to remove it of course, I barely did anything anyway.

Hope you like it!